### PR TITLE
Update fastqc, trim_galore to improve cache-ability in preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Tweaked fastqc and trim\_galore tools to make them cache-able
+
 ## [2.0.0] - 2019-03-29
 
 ### Added

--- a/tools/fastqc.cwl
+++ b/tools/fastqc.cwl
@@ -12,13 +12,22 @@ hints:
         s:citation: https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 
 requirements:
+  # Place input file into output directory, because fastqc
+  # will by default write to the same directory as the input.
+  # While fastqc does have a -o option for specifying the
+  # output directory, it causes the command-line to change
+  # from one run to the next, and therefore cannot be cached.
+  - class: InitialWorkDirRequirement
+    listing:
+      - $(inputs.input_fastq_file)
   - class: InlineJavascriptRequirement
-
 inputs:
   input_fastq_file:
     type: File
     inputBinding:
       position: 4
+      valueFrom: $(self.basename)
+
   noextract:
     type: boolean
     default: true
@@ -39,7 +48,6 @@ inputs:
       position: 5
       prefix: "--threads"
 
-
 outputs:
   output_qc_report:
     type: File
@@ -49,10 +57,7 @@ outputs:
 baseCommand: fastqc
 arguments:
   - valueFrom: $('/tmp')
-    prefix: "--dir"
-    position: 5
-  - valueFrom: $(runtime.outdir)
-    prefix: "-o"
+    prefix: "--dir" # Temp directory to use when writing report images
     position: 5
 
 $namespaces:

--- a/tools/trim_galore.cwl
+++ b/tools/trim_galore.cwl
@@ -43,10 +43,6 @@ outputs:
       glob: "*_trimming_report.txt"
 
 baseCommand: trim_galore
-arguments:
-  - valueFrom: $(runtime.outdir)
-    prefix: "-o"
-    position: 2
 
 $namespaces:
   s: https://schema.org/


### PR DESCRIPTION
When using cwltool with the `--cachedir` option, its `command_line_tool` builds up a cache key from the tool's input files, command-line and requirements (e.g. docker image). Through experimentation, I found that the command-lines for fastqc and trim\_galore were changing on each run of the workflow.

See https://github.com/common-workflow-language/cwltool/blob/4a31f2a1c1163492ae37bbc748a299e8318c462c/cwltool/command_line_tool.py#L328-L355

These tools used `$(runtime.outdir)` to build their command-lines. The runtime outdir is a random directory and changes on every run, causing these steps to never be cacheable. Since all of the downstream processing depends on the trimmed reads, the rest of the workflow was never cacheable.

This PR changes those definitions to use CWL features (InitialWorkdirRequirement for fastqc) or lean on tool default behavior (for trim\_galore), allowing every step of the preprocessing workflow to be cached.