### PR TITLE
Toil and slurm compatibility changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Changed variant recalibration for Indels and SNPs to hard code resource values.
+  This is to compatible with toil due to a bug: https://github.com/DataBiosphere/toil/issues/2814
+- Increased memory requirements for some tools to fix out of memory errors when running under toil/slurm.
+  These requirements may be higher than necessary for workflow runners outside of toil.
+
 ## [2.0.1] - 2019-04-30
 
 - Tweaked fastqc and trim\_galore tools to make them cache-able

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed variant recalibration for Indels and SNPs to hard code resource values.
   This is to compatible with toil due to a bug: https://github.com/DataBiosphere/toil/issues/2814
-- Increased memory requirements for some tools to fix out of memory errors when running under toil/slurm.
-  These requirements may be higher than necessary for workflow runners outside of toil.
+- Increased memory requirements for MarkDuplicates to fix out of memory errors when running under toil/slurm.
 
 ## [2.0.1] - 2019-04-30
 

--- a/examples/tools/GATK4-VariantRecalibrator-INDELs.json
+++ b/examples/tools/GATK4-VariantRecalibrator-INDELs.json
@@ -15,31 +15,6 @@
   "annotations": ["FS", "ReadPosRankSum", "MQRankSum", "QD", "SOR", "DP"],
   "mode": "INDEL",
   "max_gaussians": 4,
-  "resources": [
-    {
-      "name": "mills",
-      "known": false,
-      "training": true,
-      "truth": true,
-      "prior": 12,
-      "file": { "basename": "mills.vcf", "class": "File", "contents": "mills" }
-    },
-    {
-      "name": "axiomPoly",
-      "known": false,
-      "training": true,
-      "truth": false,
-      "prior": 10,
-      "file": { "basename": "axiomPoly.vcf", "class": "File", "contents": "axiomPoly" }
-    },
-    {
-      "name": "dbsnp",
-      "known": true,
-      "training": false,
-      "truth": false,
-      "prior":2,
-      "file": { "basename": "dbSNP.vcf", "class": "File", "contents": "dbSNP" }
-    }
-  ]
-
+  "resource_mills": { "basename": "mills.vcf", "class": "File", "contents": "mills" },
+  "resource_dbsnp": { "basename": "dbSNP.vcf", "class": "File", "contents": "dbSNP" }
 }

--- a/examples/tools/GATK4-VariantRecalibrator-SNPs.json
+++ b/examples/tools/GATK4-VariantRecalibrator-SNPs.json
@@ -15,39 +15,8 @@
   "annotations": ["QD", "MQRankSum", "ReadPosRankSum", "FS", "MQ", "SOR", "DP"],
   "mode": "SNP",
   "max_gaussians": 6,
-  "resources": [
-    {
-      "name": "hapmap",
-      "known": false,
-      "training": true,
-      "truth": true,
-      "prior":15,
-      "file": { "basename": "hapmap.vcf", "class": "File", "contents": "hapmap" }
-    },
-    {
-      "name": "omni",
-      "known": false,
-      "training": true,
-      "truth": true,
-      "prior":12,
-      "file": { "basename": "omni.vcf", "class": "File", "contents": "omni" }
-    },
-    {
-      "name": "1000G",
-      "known": false,
-      "training": true,
-      "truth": false,
-      "prior":10,
-      "file": { "basename": "1000genomes.vcf", "class": "File", "contents": "1000genomes" }
-    },
-    {
-      "name": "dbsnp",
-      "known": true,
-      "training": false,
-      "truth": false,
-      "prior":7,
-      "file": { "basename": "dbSNP.vcf", "class": "File", "contents": "dbSNP" }
-    }
-  ]
-
+  "resource_hapmap": { "basename": "hapmap.vcf", "class": "File", "contents": "hapmap" },
+  "resource_omni": { "basename": "omni.vcf", "class": "File", "contents": "omni" },
+  "resource_1kg": { "basename": "1000genomes.vcf", "class": "File", "contents": "1000genomes" },
+  "resource_dbsnp": { "basename": "dbSNP.vcf", "class": "File", "contents": "dbSNP" }
 }

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -101,7 +101,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 4096
+        ramMin: 8192
     scatter: [files, output_filename]
     scatterMethod: dotproduct
     in:
@@ -114,7 +114,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 4
-        ramMin: 3072
+        ramMin: 24576
     scatter: input_fastq_file
     in:
       input_fastq_file: combine_reads/output
@@ -202,7 +202,7 @@ steps:
     run: ../tools/GATK4/GATK4-ApplyBQSR.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 6144
+        ramMin: 12288
     in:
       reference: reference_genome
       input_bam: mark_duplicates/output_dedup_bam_file
@@ -219,7 +219,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 14336
+        ramMin: 24576
     in:
       reference: reference_genome
       input_bam: recalibrate_02_apply_bqsr/output_recalibrated_bam

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -167,7 +167,7 @@ steps:
     run: ../tools/GATK4/GATK4-MarkDuplicates.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 16384
+        ramMin: 49152
         outdirMin: 12288
         tmpdirMin: 12288
     in:
@@ -187,7 +187,7 @@ steps:
     run: ../tools/GATK4/GATK4-BaseRecalibrator.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 8192
+        ramMin: 16384
     in:
       reference: reference_genome
       input_bam: mark_duplicates/output_dedup_bam_file

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -101,7 +101,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 8192
+        ramMin: 1024
     scatter: [files, output_filename]
     scatterMethod: dotproduct
     in:
@@ -114,7 +114,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 4
-        ramMin: 24576
+        ramMin: 3072
     scatter: input_fastq_file
     in:
       input_fastq_file: combine_reads/output
@@ -167,7 +167,7 @@ steps:
     run: ../tools/GATK4/GATK4-MarkDuplicates.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 49152
+        ramMin: 32768
         outdirMin: 12288
         tmpdirMin: 12288
     in:
@@ -187,7 +187,7 @@ steps:
     run: ../tools/GATK4/GATK4-BaseRecalibrator.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 16384
+        ramMin: 8192
     in:
       reference: reference_genome
       input_bam: mark_duplicates/output_dedup_bam_file
@@ -202,7 +202,7 @@ steps:
     run: ../tools/GATK4/GATK4-ApplyBQSR.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 12288
+        ramMin: 6144
     in:
       reference: reference_genome
       input_bam: mark_duplicates/output_dedup_bam_file
@@ -219,7 +219,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 24576
+        ramMin: 14336
     in:
       reference: reference_genome
       input_bam: recalibrate_02_apply_bqsr/output_recalibrated_bam

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -219,7 +219,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 14336
+        ramMin: 18432
     in:
       reference: reference_genome
       input_bam: recalibrate_02_apply_bqsr/output_recalibrated_bam

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -101,7 +101,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 1
-        ramMin: 1024
+        ramMin: 4096
     scatter: [files, output_filename]
     scatterMethod: dotproduct
     in:

--- a/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
+++ b/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
@@ -149,7 +149,7 @@ steps:
     out:
       - annotations
   variant_recalibration_indels:
-    run: ../tools/GATK4/GATK4-VariantRecalibrator.cwl
+    run: ../tools/GATK4/GATK4-VariantRecalibrator-Indels.cwl
     requirements:
       - class: ResourceRequirement
         coresMin: 2
@@ -163,19 +163,13 @@ steps:
       annotations: generate_annotations_indels/annotations
       mode: { default: "INDEL" }
       max_gaussians: { default: 4}
-      resources:
-        source: [indel_resource_mills, resource_dbsnp]
-        linkMerge: merge_flattened
-        valueFrom: >
-          $([
-            { name: "mills", known: false, training: true, truth: true, prior: 12, file: self[0] },
-            { name: "dbsnp", known: true, training: false, truth: false, prior: 2, file: self[1] }
-          ])
+      resource_mills: indel_resource_mills
+      resource_dbsnp: resource_dbsnp
     out:
       - output_recalibration
       - output_tranches
   variant_recalibration_snps:
-    run: ../tools/GATK4/GATK4-VariantRecalibrator.cwl
+    run: ../tools/GATK4/GATK4-VariantRecalibrator-SNPs.cwl
     requirements:
       - class: ResourceRequirement
         coresMin: 2
@@ -189,16 +183,10 @@ steps:
       annotations: generate_annotations_snps/annotations
       mode: { default: "SNP" }
       max_gaussians: { default: 6}
-      resources:
-        source: [snp_resource_hapmap, snp_resource_omni, snp_resource_1kg, resource_dbsnp]
-        linkMerge: merge_flattened
-        valueFrom: >
-          $([
-              { name: "hapmap", known: false, training: true, truth: true, prior: 15, file: self[0] },
-              { name: "omni", known: false, training: true, truth: true, prior: 12, file: self[1] },
-              { name: "1000G", known: false, training: true, truth: false, prior: 10, file: self[2] },
-              { name: "dbsnp", known: true, training: false, truth: false, prior: 7, file: self[3] },
-          ])
+      resource_hapmap: snp_resource_hapmap
+      resource_omni: snp_resource_omni
+      resource_1kg: snp_resource_1kg
+      resource_dbsnp: resource_dbsnp
     out:
       - output_recalibration
       - output_tranches

--- a/tools/GATK4/GATK4-VariantRecalibrator-SNPs.cwl
+++ b/tools/GATK4/GATK4-VariantRecalibrator-SNPs.cwl
@@ -1,0 +1,122 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+requirements:
+  $import: GATK4-requirements.yml
+hints:
+  - $import: GATK4-hints.yml
+baseCommand: gatk
+
+inputs:
+  variants:
+    type: File
+    inputBinding:
+      prefix: -V
+      position: 1
+    secondaryFiles:
+      - .idx
+    doc: One or more VCF files containing variants  Required.
+  output_recalibration_filename:
+    type: string
+    inputBinding:
+      prefix: -O
+      position: 2
+    doc: The output recal file used by ApplyRecalibration  Required.
+  output_tranches_filename:
+    type: string
+    inputBinding:
+      prefix: --tranches-file
+      position: 3
+    doc:  The output tranches file used by ApplyRecalibration  Required.
+  trust_all_polymorphic:
+    type: boolean?
+    inputBinding:
+      prefix: --trust-all-polymorphic
+      position: 4
+    doc: "Trust that all the input training sets' unfiltered records contain only polymorphic sites to drastically speed up the computation.  Default value: false."
+  tranches:
+    type:
+      type: array
+      items: string
+      inputBinding:
+        prefix: -tranche
+    inputBinding:
+      position: 5
+  annotations:
+    type:
+      type: array
+      items: string
+      inputBinding:
+        prefix: -an
+    inputBinding:
+      position: 6
+    doc: The names of the annotations which should used for calculations
+  mode:
+    type:
+      type: enum
+      symbols: [SNP,INDEL,BOTH]
+    inputBinding:
+      prefix: -mode
+      position: 7
+    doc: "Recalibration mode to employ  Default value: SNP. Possible values: {SNP, INDEL, BOTH}"
+  max_gaussians:
+    type: int?
+    inputBinding:
+      prefix: --max-gaussians
+      position: 8
+    doc: "Max number of Gaussians for the positive model  Default value: 8."
+  resource_hapmap:
+    type: File
+    secondaryFiles:
+    - .idx
+    doc: hapmap reference data
+  resource_omni:
+    type: File
+    secondaryFiles:
+    - .idx
+    doc: omni reference data
+  resource_1kg:
+    type: File
+    secondaryFiles:
+    - .idx
+    doc: 1000 genome reference data
+  resource_dbsnp:
+    type: File
+    secondaryFiles:
+    - .idx
+    doc: dbSNP reference data
+  java_opt:
+    type: string
+    doc: "String of options to pass to JVM at runtime"
+    inputBinding:
+      prefix: "--java-options"
+      position: -1 # before the tool name
+      shellQuote: true
+
+outputs:
+  output_recalibration:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_recalibration_filename)
+    secondaryFiles:
+      - .idx
+  output_tranches:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_tranches_filename)
+
+arguments:
+  - VariantRecalibrator
+
+  - -resource
+  - "hapmap,known=false,training=true,truth=true,prior=15.0:$(inputs.resource_hapmap.path)"
+
+  - -resource
+  - "omni,known=false,training=true,truth=true,prior=12.0:$(inputs.resource_omni.path)"
+
+  - -resource
+  - "1000G,known=false,training=true,truth=false,prior=10.0:$(inputs.resource_1kg.path)"
+
+  - -resource
+  - "dbsnp,known=true,training=false,truth=false,prior=7.0:$(inputs.resource_dbsnp.path)"


### PR DESCRIPTION
Changes variant recalibration step for Indels and SNPs to use a tool with hard coded resource values to work around an issue with toil and passing arrays (https://github.com/DataBiosphere/toil/issues/2814). 
Increases the memory requirements for the mark duplicate steps.
