### PR TITLE
save mark duplicate metric reports

### DIFF
--- a/exomeseq-gatk4-preprocessing.cwl
+++ b/exomeseq-gatk4-preprocessing.cwl
@@ -58,7 +58,7 @@ outputs:
   markduplicates_metrics:
     type: File
     outputSource: preprocessing/markduplicates_metrics
-    doc: "BAM and bai files from markduplicates"
+    doc: "metrics file from markduplicates"
   recalibration_table:
     type: File
     outputSource: preprocessing/recalibration_table

--- a/exomeseq-gatk4-preprocessing.cwl
+++ b/exomeseq-gatk4-preprocessing.cwl
@@ -55,6 +55,10 @@ outputs:
     type: File
     outputSource: preprocessing/markduplicates_bam
     doc: "BAM and bai files from markduplicates"
+  markduplicates_metrics:
+    type: File
+    outputSource: preprocessing/markduplicates_metrics
+    doc: "BAM and bai files from markduplicates"
   recalibration_table:
     type: File
     outputSource: preprocessing/recalibration_table
@@ -99,6 +103,7 @@ steps:
       - fastqc_reports
       - trim_reports
       - markduplicates_bam
+      - markduplicates_metrics
       - recalibration_table
       - recalibrated_reads
       - raw_variants

--- a/exomeseq-gatk4.cwl
+++ b/exomeseq-gatk4.cwl
@@ -82,6 +82,10 @@ outputs:
     type: Directory
     outputSource: organize_directories/bams_markduplicates_dir
     doc: "BAM and bai files from markduplicates"
+  markduplicates_metrics_dir:
+    type: Directory
+    outputSource: organize_directories/metrics_markduplicates_dir
+    doc: "metrics files from markduplicates"
   bams_recalibrated_dir:
     type: Directory
     outputSource: organize_directories/bams_recalibrated_dir
@@ -129,6 +133,7 @@ steps:
       - fastqc_reports
       - trim_reports
       - markduplicates_bam
+      - markduplicates_metrics
       - recalibration_table
       - recalibrated_reads
       - raw_variants
@@ -164,11 +169,13 @@ steps:
       fastqc_reports: preprocessing/fastqc_reports
       trim_reports: preprocessing/trim_reports
       bams_markduplicates: preprocessing/markduplicates_bam
+      metrics_markduplicates: preprocessing/markduplicates_metrics
       raw_variants: preprocessing/raw_variants
       bams_recalibrated: preprocessing/recalibrated_reads
     out:
       - fastqc_reports_dir
       - trim_reports_dir
       - bams_markduplicates_dir
+      - metrics_markduplicates_dir
       - raw_variants_dir
       - bams_recalibrated_dir

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -56,6 +56,9 @@ outputs:
   markduplicates_bam:
     type: File
     outputSource: mark_duplicates/output_dedup_bam_file
+  markduplicates_metrics:
+    type: File
+    outputSource: mark_duplicates/output_metrics_file
   # Recalibration
   recalibration_table:
     type: File

--- a/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
+++ b/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
@@ -8,6 +8,7 @@ inputs:
   trim_reports:
     type: { type: array, items: { type: array, items: File } }
   bams_markduplicates: File[]
+  metrics_markduplicates: File[]
   raw_variants: File[]
   bams_recalibrated: File[]
 outputs:
@@ -20,6 +21,9 @@ outputs:
   bams_markduplicates_dir:
     type: Directory
     outputSource: org_bams_markduplicates/outdir
+  metrics_markduplicates_dir:
+    type: Directory
+    outputSource: org_metrics_markduplicates/outdir
   raw_variants_dir:
     type: Directory
     outputSource: org_raw_variants/outdir
@@ -49,6 +53,14 @@ steps:
       name:
         default: 'bams-markduplicates'
       files: bams_markduplicates
+    out:
+      - outdir
+  org_metrics_markduplicates:
+    run: ../utils/files-to-directory.cwl
+    in:
+      name:
+        default: 'metrics-markduplicates'
+      files: metrics_markduplicates
     out:
       - outdir
   org_raw_variants:


### PR DESCRIPTION
Changes main workflow to saves metric reports created by the mark duplicate step into a new output directory named `metrics-markduplicates`. Changes preprocessing workflow to save the metric reports as well. Before this change the mark duplicate metric reports were being generated but discarded.

Fixes #16 