### PR TITLE
Updates to use fastp instead of fastqc+trim_galore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated workflows to use [fastp](https://github.com/OpenGene/fastp) instead of FastQC and Trim Galore for performance.
+
 ## [2.0.3] - 2020-01-08
 
 - Changed variant recalibration for Indels and SNPs to hard code resource values.

--- a/exomeseq-gatk4-preprocessing.cwl
+++ b/exomeseq-gatk4-preprocessing.cwl
@@ -45,12 +45,14 @@ inputs:
     secondaryFiles:
     - .idx
 outputs:
-  fastqc_reports:
-    type: File[]
-    outputSource: preprocessing/fastqc_reports
-  trim_reports:
-    type: File[]
-    outputSource: preprocessing/trim_reports
+  fastp_html_report:
+    type: File
+    outputSource: preprocessing/fastp_html_reports
+    doc: "QC/Trim report from fastp in HTML format"
+  fastp_json_report:
+    type: File
+    outputSource: fastp/json_report
+    doc: "QC/Trim report from fastp in JSON format"
   markduplicates_bam:
     type: File
     outputSource: preprocessing/markduplicates_bam
@@ -100,8 +102,8 @@ steps:
       known_sites: known_sites
       resource_dbsnp: resource_dbsnp
     out:
-      - fastqc_reports
-      - trim_reports
+      - fastp_html_report
+      - fastp_json_report
       - markduplicates_bam
       - markduplicates_metrics
       - recalibration_table

--- a/exomeseq-gatk4-preprocessing.cwl
+++ b/exomeseq-gatk4-preprocessing.cwl
@@ -47,11 +47,11 @@ inputs:
 outputs:
   fastp_html_report:
     type: File
-    outputSource: preprocessing/fastp_html_reports
+    outputSource: preprocessing/fastp_html_report
     doc: "QC/Trim report from fastp in HTML format"
   fastp_json_report:
     type: File
-    outputSource: fastp/json_report
+    outputSource: preprocessing/fastp_json_report
     doc: "QC/Trim report from fastp in JSON format"
   markduplicates_bam:
     type: File

--- a/exomeseq-gatk4.cwl
+++ b/exomeseq-gatk4.cwl
@@ -69,12 +69,12 @@ inputs:
     secondaryFiles:
     - .idx
 outputs:
-  fastqc_reports_dir:
+  fastp_html_reports_dir:
     type: Directory
-    outputSource: organize_directories/fastqc_reports_dir
-  trim_reports_dir:
+    outputSource: organize_directories/fastp_html_reports_dir
+  fastp_json_reports_dir:
     type: Directory
-    outputSource: organize_directories/trim_reports_dir
+    outputSource: organize_directories/fastp_json_reports_dir
   raw_variants_dir:
     type: Directory
     outputSource: organize_directories/raw_variants_dir
@@ -130,8 +130,8 @@ steps:
       known_sites: known_sites
       resource_dbsnp: resource_dbsnp
     out:
-      - fastqc_reports
-      - trim_reports
+      - fastp_html_report
+      - fastp_json_report
       - markduplicates_bam
       - markduplicates_metrics
       - recalibration_table
@@ -166,15 +166,15 @@ steps:
   organize_directories:
     run: subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
     in:
-      fastqc_reports: preprocessing/fastqc_reports
-      trim_reports: preprocessing/trim_reports
+      fastp_html_reports: preprocessing/fastp_html_report
+      fastp_json_reports: preprocessing/fastp_json_report
       bams_markduplicates: preprocessing/markduplicates_bam
       metrics_markduplicates: preprocessing/markduplicates_metrics
       raw_variants: preprocessing/raw_variants
       bams_recalibrated: preprocessing/recalibrated_reads
     out:
-      - fastqc_reports_dir
-      - trim_reports_dir
+      - fastp_html_reports_dir
+      - fastp_json_reports_dir
       - bams_markduplicates_dir
       - metrics_markduplicates_dir
       - raw_variants_dir

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -121,7 +121,7 @@ steps:
       ramMin: 2048
     in:
       reads: combine_reads/output
-      trimmed_reads_filenames: file_pair_details/trimmed_reads_output_filenames
+      trimmed_reads_filenames: generate_sample_filenames/trimmed_reads_output_filenames
       report_base_filename: file_pair_details/read_pair_name
       threads: { default: 4 }
     out:

--- a/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
+++ b/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
@@ -3,18 +3,19 @@
 cwlVersion: v1.0
 class: Workflow
 inputs:
-  fastqc_reports:
-    type: { type: array, items: { type: array, items: File } }
-  trim_reports:
-    type: { type: array, items: { type: array, items: File } }
+  fastp_html_reports: File[]
+  fastp_json_reports: File[]
   bams_markduplicates: File[]
   metrics_markduplicates: File[]
   raw_variants: File[]
   bams_recalibrated: File[]
 outputs:
-  fastqc_reports_dir:
+  fastp_html_reports_dir:
     type: Directory
-    outputSource: org_fastqc_reports/outdir
+    outputSource: org_fastp_html_reports/outdir
+  fastp_json_reports_dir:
+    type: Directory
+    outputSource: org_fastp_json_reports/outdir
   trim_reports_dir:
     type: Directory
     outputSource: org_trim_reports/outdir
@@ -31,20 +32,20 @@ outputs:
     type: Directory
     outputSource: org_bams_recalibrated/outdir
 steps:
-  org_fastqc_reports:
-    run: ../utils/file-pairs-to-directory.cwl
+  org_fastp_html_reports:
+    run: ../utils/files-to-directory.cwl
     in:
       name:
-        default: 'fastqc-reports'
-      file_pairs: fastqc_reports
+        default: 'fastp-html-reports'
+      files: fastp_html_reports
     out:
       - outdir
-  org_trim_reports:
-    run: ../utils/file-pairs-to-directory.cwl
+  org_fastp_json_reports:
+    run: ../utils/files-to-directory.cwl
     in:
       name:
-        default: 'trim-reports'
-      file_pairs: trim_reports
+        default: 'fastp-json-reports'
+      files: fastp_json_reports
     out:
       - outdir
   org_bams_markduplicates:

--- a/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
+++ b/subworkflows/exomeseq-gatk4-03-organizedirectories.cwl
@@ -16,9 +16,6 @@ outputs:
   fastp_json_reports_dir:
     type: Directory
     outputSource: org_fastp_json_reports/outdir
-  trim_reports_dir:
-    type: Directory
-    outputSource: org_trim_reports/outdir
   bams_markduplicates_dir:
     type: Directory
     outputSource: org_bams_markduplicates/outdir

--- a/tools/fastp-pe.cwl
+++ b/tools/fastp-pe.cwl
@@ -11,7 +11,7 @@ hints:
   - class: SoftwareRequirement
     packages:
       fastp:
-        version: [ "0.20.0-0" ]
+        version: [ "0.20.0" ]
         s:citation: https://doi.org/10.1093/bioinformatics/bty560
 
 inputs:

--- a/tools/fastp-pe.cwl
+++ b/tools/fastp-pe.cwl
@@ -15,26 +15,12 @@ hints:
         s:citation: https://doi.org/10.1093/bioinformatics/bty560
 
 inputs:
-  read1:
-    type: File
-    doc: "read1 input file name (string [=])"
-    inputBinding:
-      prefix: '-i'
-  read2:
-    type: File
-    doc: "read2 input file name (string [=])"
-    inputBinding:
-      prefix: '-I'
-  trimmed_read1_filename:
-    type: string
-    doc: "read1 output file name (string [=]). The output will be gzip-compressed if its file name ends with .gz"
-    inputBinding:
-      prefix: '-O'
-  trimmed_read2_filename:
-    type: string
-    doc: "read2 output file name (string [=]). The output will be gzip-compressed if its file name ends with .gz"
-    inputBinding:
-      prefix: '-o'
+  reads:
+    type: File[]
+    doc: "read1 and read2 input files array"
+  trimmed_reads_filenames:
+    type: string[]
+    doc: "Array of output file names. The output will be gzip-compressed if its file name ends with .gz"
   report_base_filename:
     type: string
     doc: "Prefix to use for HTML and JSON report files"
@@ -45,14 +31,10 @@ inputs:
       prefix: '-w'
 
 outputs:
-  trimmed_read1:
-    type: File
+  trimmed_reads:
+    type: File[]
     outputBinding:
-      glob: $(inputs.trimmed_read1_filename)
-  trimmed_read2:
-    type: File
-    outputBinding:
-      glob: $(inputs.trimmed_read2_filename)
+      glob: $(inputs.trimmed_reads_filenames)
   html_report:
     type: File
     outputBinding:
@@ -63,11 +45,22 @@ outputs:
       glob: $(inputs.report_prefix + ".json")
 
 baseCommand: fastp
-arguments: ["-j", $(inputs.report_prefix + ".json"), "-h", $(inputs.report_prefix + ".html")]
+arguments:
+  - "-I"
+  - $(inputs.reads[0])
+  - "-i"
+  - $(inputs.reads[1])
+  - "-O"
+  - $(inputs.trimmed_reads_filenames[0])
+  - "-o"
+  - $(inputs.trimmed_reads_filenames[1])
+  - "-j"
+  - $(inputs.report_prefix + ".json")
+  - "-h"
+  - $(inputs.report_prefix + ".html")
+
 $namespaces:
   s: https://schema.org/
 
 $schemas:
  - https://schema.org/docs/schema_org_rdfa.html
-
-# CPUs: same as threads. mem usage: 1.1GB

--- a/tools/fastp-pe.cwl
+++ b/tools/fastp-pe.cwl
@@ -38,11 +38,11 @@ outputs:
   html_report:
     type: File
     outputBinding:
-      glob: $(inputs.report_prefix + ".html")
+      glob: $(inputs.report_base_filename + ".html")
   json_report:
     type: File
     outputBinding:
-      glob: $(inputs.report_prefix + ".json")
+      glob: $(inputs.report_base_filename + ".json")
 
 baseCommand: fastp
 arguments:
@@ -55,9 +55,9 @@ arguments:
   - "-o"
   - $(inputs.trimmed_reads_filenames[1])
   - "-j"
-  - $(inputs.report_prefix + ".json")
+  - $(inputs.report_base_filename + ".json")
   - "-h"
-  - $(inputs.report_prefix + ".html")
+  - $(inputs.report_base_filename + ".html")
 
 $namespaces:
   s: https://schema.org/

--- a/tools/fastp-pe.cwl
+++ b/tools/fastp-pe.cwl
@@ -2,6 +2,9 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
+requirements:
+  - class: InlineJavascriptRequirement
+
 hints:
   - class: DockerRequirement
     dockerPull: 'quay.io/biocontainers/fastp:0.20.0--hdbcaa40_0'
@@ -32,22 +35,14 @@ inputs:
     doc: "read2 output file name (string [=]). The output will be gzip-compressed if its file name ends with .gz"
     inputBinding:
       prefix: '-o'
-  html_report_filename:
-    type: string?
-    doc: "the html format report file name (string [=fastp.html])"
-    inputBinding:
-      prefix: '-h'
-  json_report_filename:
-    type: string?
-    doc: "the json format report file name (string [=fastp.json])"
-    inputBinding:
-      prefix: '-j'
+  report_base_filename:
+    type: string
+    doc: "Prefix to use for HTML and JSON report files"
   threads:
     type: int?
     doc: "worker thread number, default is 2 (int [=2])"
     inputBinding:
       prefix: '-w'
-
 
 outputs:
   trimmed_read1:
@@ -61,15 +56,14 @@ outputs:
   html_report:
     type: File
     outputBinding:
-      glob: "*.html"
+      glob: $(inputs.report_prefix + ".html")
   json_report:
     type: File
     outputBinding:
-      glob: "*.json"
-
+      glob: $(inputs.report_prefix + ".json")
 
 baseCommand: fastp
-
+arguments: ["-j", $(inputs.report_prefix + ".json"), "-h", $(inputs.report_prefix + ".html")]
 $namespaces:
   s: https://schema.org/
 

--- a/tools/fastp-pe.cwl
+++ b/tools/fastp-pe.cwl
@@ -1,0 +1,79 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+hints:
+  - class: DockerRequirement
+    dockerPull: 'quay.io/biocontainers/fastp:0.20.0--hdbcaa40_0'
+  - class: SoftwareRequirement
+    packages:
+      fastp:
+        version: [ "0.20.0-0" ]
+        s:citation: https://doi.org/10.1093/bioinformatics/bty560
+
+inputs:
+  read1:
+    type: File
+    doc: "read1 input file name (string [=])"
+    inputBinding:
+      prefix: '-i'
+  read2:
+    type: File
+    doc: "read2 input file name (string [=])"
+    inputBinding:
+      prefix: '-I'
+  trimmed_read1_filename:
+    type: string
+    doc: "read1 output file name (string [=]). The output will be gzip-compressed if its file name ends with .gz"
+    inputBinding:
+      prefix: '-O'
+  trimmed_read2_filename:
+    type: string
+    doc: "read2 output file name (string [=]). The output will be gzip-compressed if its file name ends with .gz"
+    inputBinding:
+      prefix: '-o'
+  html_report_filename:
+    type: string?
+    doc: "the html format report file name (string [=fastp.html])"
+    inputBinding:
+      prefix: '-h'
+  json_report_filename:
+    type: string?
+    doc: "the json format report file name (string [=fastp.json])"
+    inputBinding:
+      prefix: '-j'
+  threads:
+    type: int?
+    doc: "worker thread number, default is 2 (int [=2])"
+    inputBinding:
+      prefix: '-w'
+
+
+outputs:
+  trimmed_read1:
+    type: File
+    outputBinding:
+      glob: $(inputs.trimmed_read1_filename)
+  trimmed_read2:
+    type: File
+    outputBinding:
+      glob: $(inputs.trimmed_read2_filename)
+  html_report:
+    type: File
+    outputBinding:
+      glob: "*.html"
+  json_report:
+    type: File
+    outputBinding:
+      glob: "*.json"
+
+
+baseCommand: fastp
+
+$namespaces:
+  s: https://schema.org/
+
+$schemas:
+ - https://schema.org/docs/schema_org_rdfa.html
+
+# CPUs: same as threads. mem usage: 1.1GB

--- a/utils/generate-sample-filenames.cwl
+++ b/utils/generate-sample-filenames.cwl
@@ -10,6 +10,7 @@ inputs:
   sample_name: string
 outputs:
   combined_reads_output_filenames: string[]
+  trimmed_reads_output_filenames: string[]
   mapped_reads_output_filename: string
   sorted_reads_output_filename: string
   dedup_reads_output_filename: string
@@ -32,6 +33,10 @@ expression: >
       combined_reads_output_filenames: [
         makeFilename(base, 'R1', 'fastq.gz'),
         makeFilename(base, 'R2', 'fastq.gz'),
+      ],
+      trimmed_reads_output_filenames: [
+        makeFilename(base, 'R1-trimmed', 'fastq.gz'),
+        makeFilename(base, 'R2-trimmed', 'fastq.gz'),
       ],
       mapped_reads_output_filename: makeFilename(base, 'mapped', 'bam'),
       sorted_reads_output_filename: makeFilename(base, 'sorted', 'bam'),


### PR DESCRIPTION
- Adds `tools/fastp-pe.cwl` tool to wrap fastp 0.20.0 from biocontainers
- Updates utils to generate appropriate filenames for trimmed reads
- Replaces `fastqc_reports` `trim_reports` outputs (from fastqc/trim_galore) with `fastp_html_report` and `fastp_json_report`

I've tested and verified the tool works in the preprocessing workflow, and reviewed the input/output connections for the full workflow. I have a test job underway, but believe it's ready for testing from the `develop` branch.