### PR TITLE
Increase memory requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increased BaseRecalibrator memory requirement to 12G.
+- Increased CombineGVCFs memory requirement to 16G.
 - Updated workflows to use [fastp](https://github.com/OpenGene/fastp) instead of FastQC and Trim Galore for performance.
 
 ### Removed

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -180,7 +180,7 @@ steps:
     run: ../tools/GATK4/GATK4-BaseRecalibrator.cwl
     requirements:
       - class: ResourceRequirement
-        ramMin: 8192
+        ramMin: 12288
     in:
       reference: reference_genome
       input_bam: mark_duplicates/output_dedup_bam_file

--- a/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
+++ b/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
@@ -106,7 +106,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: 2
-        ramMin: 10240
+        ramMin: 16384
     in:
       reference: reference_genome
       output_vcf_filename: generate_joint_filenames/raw_variants_filename


### PR DESCRIPTION
Increases memory requirements for BaseRecalibrator and CombineGVCFs steps.
These changes were added to address a problem where a user's job was terminated by slurm due to using too much memory.