### PR TITLE
fix workflow version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2020-02-26
+### Changed
+- Fixes out of date version numbers in exomeseq-gatk4.cwl and exomeseq-gatk4-preprocessing.cwl
+
 ## [2.1.0] - 2020-02-26
 
 ### Changed

--- a/exomeseq-gatk4-preprocessing.cwl
+++ b/exomeseq-gatk4-preprocessing.cwl
@@ -1,8 +1,8 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: Workflow
-label: exomeseq-gatk4-preprocessing/v2.1.0
-doc: Whole Exome Sequence preprocessing using GATK4 - v2.1.0
+label: exomeseq-gatk4-preprocessing/v2.1.1
+doc: Whole Exome Sequence preprocessing using GATK4 - v2.1.1
 requirements:
   ScatterFeatureRequirement: {}
   SubworkflowFeatureRequirement: {}

--- a/exomeseq-gatk4.cwl
+++ b/exomeseq-gatk4.cwl
@@ -1,8 +1,8 @@
 #!/usr/bin/env cwl-runner
 cwlVersion: v1.0
 class: Workflow
-label: exomeseq-gatk4/v2.1.0
-doc: Whole Exome Sequence analysis using GATK4 - v2.1.0
+label: exomeseq-gatk4/v2.1.1
+doc: Whole Exome Sequence analysis using GATK4 - v2.1.1
 requirements:
   - class: ScatterFeatureRequirement
   - class: SubworkflowFeatureRequirement


### PR DESCRIPTION
Earlier I missed a step in https://github.com/bespin-workflows/workflow-standards#development-and-release-process where we update the version numbers within the top level workflows.
This fixes that problem with a new release.