### PR TITLE
Convert BWA output to BAM and sort simultaneously

### DIFF
--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -133,7 +133,7 @@ steps:
     requirements:
       - class: ResourceRequirement
         coresMin: $(inputs.threads)
-        ramMin: 14336
+        ramMin: 15336
         outdirMin: 12288
         tmpdirMin: 12288
     in:

--- a/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
+++ b/subworkflows/exomeseq-gatk4-01-preprocessing.cwl
@@ -143,18 +143,6 @@ steps:
       output_filename: generate_sample_filenames/mapped_reads_output_filename
       threads: threads
     out:
-      - output
-  sort:
-    run: ../tools/GATK4/GATK4-SortSam.cwl
-    requirements:
-      - class: ResourceRequirement
-        ramMin: 16384
-    in:
-      input_file: map/output
-      output_sorted_bam_filename: generate_sample_filenames/sorted_reads_output_filename
-      sort_order: { default: "coordinate" }
-      java_opt: { default: "-Xms4g" }
-    out:
       - output_sorted_bam
   mark_duplicates:
     run: ../tools/GATK4/GATK4-MarkDuplicates.cwl
@@ -164,7 +152,7 @@ steps:
         outdirMin: 12288
         tmpdirMin: 12288
     in:
-      input_file: sort/output_sorted_bam
+      input_file: map/output_sorted_bam
       output_filename: generate_sample_filenames/dedup_reads_output_filename
       metrics_filename: generate_sample_filenames/dedup_metrics_output_filename
       validation_stringency: { default: "SILENT" }

--- a/tools/gitc-bwa-mem-samtools.cwl
+++ b/tools/gitc-bwa-mem-samtools.cwl
@@ -11,8 +11,8 @@ requirements:
   listing:
     - entryname: bwa-mem-samtools.sh
       entry: |
-        set -o pipefail
-        /usr/gitc/bwa mem $@ | samtools view -1 -
+        set -xo pipefail
+        /usr/gitc/bwa mem $@ | samtools sort -O BAM -
 baseCommand: bash
 arguments: [bwa-mem-samtools.sh]
 
@@ -95,7 +95,7 @@ inputs:
 stdout: $(inputs.output_filename)
 
 outputs:
-  output:
+  output_sorted_bam:
     type: File
     outputBinding:
       glob: $(inputs.output_filename)


### PR DESCRIPTION
While combining these steps may not save computational time, it should reduce the storage space needed.