### PR TITLE
variant recalibration annotation parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enabling 'detect_adapters_for_pe' for fastp-pe by default
 
+### Added
+
+- Optional 'variant_recalibration_annotations_indels' and 'variant_recalibration_annotations_snps' input fields for main workflow. These override the default annotations used with the gatk4 VariantRecalibrator command.
+
 ## [2.1.1] - 2020-02-26
 
 ### Changed

--- a/exomeseq-gatk4.cwl
+++ b/exomeseq-gatk4.cwl
@@ -68,6 +68,12 @@ inputs:
     type: File
     secondaryFiles:
     - .idx
+  variant_recalibration_annotations_indels:
+    type: string[]
+    default: ["FS", "ReadPosRankSum", "MQRankSum", "QD", "SOR"]
+  variant_recalibration_annotations_snps:
+    type: string[]
+    default: ["QD", "MQRankSum", "ReadPosRankSum", "FS", "MQ", "SOR"]
 outputs:
   fastp_html_reports_dir:
     type: Directory
@@ -153,6 +159,8 @@ steps:
       snp_resource_1kg: snp_resource_1kg
       resource_dbsnp: resource_dbsnp
       indel_resource_mills: indel_resource_mills
+      variant_recalibration_annotations_indels: variant_recalibration_annotations_indels
+      variant_recalibration_annotations_snps: variant_recalibration_annotations_snps
     out:
       - joint_raw_variants
       - variant_recalibration_snps_tranches

--- a/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
+++ b/subworkflows/exomeseq-gatk4-02-variantdiscovery.cwl
@@ -52,6 +52,10 @@ inputs:
     type: File
     secondaryFiles:
     - .idx
+  variant_recalibration_annotations_indels:
+    type: string[]
+  variant_recalibration_annotations_snps:
+    type: string[]
 outputs:
   joint_raw_variants:
     type: File
@@ -136,16 +140,14 @@ steps:
     run: ../utils/generate-variant-recalibration-annotation-set.cwl
     in:
       study_type: study_type
-      base_annotations:
-        default: ["FS", "ReadPosRankSum", "MQRankSum", "QD", "SOR"]
+      base_annotations: variant_recalibration_annotations_indels
     out:
       - annotations
   generate_annotations_snps:
     run: ../utils/generate-variant-recalibration-annotation-set.cwl
     in:
       study_type: study_type
-      base_annotations:
-        default: ["QD", "MQRankSum", "ReadPosRankSum", "FS", "MQ", "SOR"]
+      base_annotations: variant_recalibration_annotations_snps
     out:
       - annotations
   variant_recalibration_indels:


### PR DESCRIPTION
Adds `variant_recalibration_annotations_indels` and `variant_recalibration_annotations_snps`
input parameters to the main workflow. These will allow overriding the default variant
recalibration input parameters which will make it possible to use this workflow with WGS data.